### PR TITLE
Added repository link to Build.PL

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -7,6 +7,10 @@ my $builder = Module::Build->new(
     license             => 'perl',
     dist_author         => q{Joseph Brenner <doom@kzsu.stanford.edu>},
     dist_version_from   => 'lib/Text/Capitalize.pm',
+    meta_merge => {
+        resources => {
+            repository => 'https://github.com/doomvox/text-capitalize'}
+    },
     build_requires => {
                        'Test::More'     => 0,
                        'FindBin'        => 1.04,


### PR DESCRIPTION
Hi Joseph,

I am Csaba from Budapest, and I am learning Perl programming right now. I have just read [Gabor Szabo's guide](https://perlmaven.com/hacktoberfest-2019) on conrtibuting to Perl during the Hacktoberfest, and found, that the repository link to Your module Text-Capitalize is missing from metaCPAN.
I thought I would update it following [Gabor's guide](https://perlmaven.com/how-to-add-link-to-version-control-system-of-a-cpan-distributions) to fix this.

Could You please review my PR and let me know if it is okay? 
If not, I would gladly work on that issue more to provide a better solution.

I hope You don't mind contacting You with such a nuance.

Thanks and Regards,
Csaba